### PR TITLE
Making external routes optional

### DIFF
--- a/web.config.js
+++ b/web.config.js
@@ -1,46 +1,49 @@
 /** @param {import('.').createWebConfigOptions} options */
 export function createWebConfig(options) {
-    const routes = Array.from(new Set(options.externalRoutes ?? []))
-    const blockRule = routes.length > 0  ? `
-                   <!-- external routes that should be handled by IIS. For example, virtual directories -->
-                   <rule name="block" stopProcessing="true">
-                       <match url="^(${routes.join('|')})/*" ignoreCase="${
+  const routes = Array.from(new Set(options.externalRoutes ?? []))
+  const blockRule =
+    routes.length > 0
+      ? `
+				<!-- external routes that should be handled by IIS. For example, virtual directories -->
+				<rule name="block" stopProcessing="true">
+					<match url="^(${routes.join('|')})/*" ignoreCase="${
           options.externalRoutesIgnoreCase ?? true
         }" />
-                       <action type="None" />
-                   </rule>` : '';
-    // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
-    return `<?xml version="1.0" encoding="utf-8"?>
-  <configuration>
-      ${
-      options.env
-        ? `
-      <appSettings>
-          ${Object.entries(options.env)
-        .map(([key, val]) => `<add key="${key}" value="${val}" />`)
-        .join('\n\t\t')}
-      </appSettings>
-      `
-        : ''
-    }
-      <system.webServer>
-          <handlers>
-              <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
-              <add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
-          </handlers>
-          <rewrite>
-              <rules>${blockRule}
-                  <rule name="app">
-                      <match url="/*" />
-                      <action type="Rewrite" url="node-server.cjs" />
-                  </rule>
-              </rules>
-          </rewrite>
-          <!-- enableXFF="true" is required for getClientAddress to work -->
-          <iisnode watchedFiles="web.config;node_modules\\*;*.js;*.cjs" nodeProcessCommandLine="${
-        options.nodePath ?? 'node.exe'
-      }" enableXFF="true" />
-      </system.webServer>
-  </configuration>
-  `
+					<action type="None" />
+				</rule>`
+      : ''
+  // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
+  return `<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	${
+    options.env
+      ? `
+	<appSettings>
+		${Object.entries(options.env)
+      .map(([key, val]) => `<add key="${key}" value="${val}" />`)
+      .join('\n\t\t')}
+	</appSettings>
+	`
+      : ''
   }
+	<system.webServer>
+		<handlers>
+			<!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+			<add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
+		</handlers>
+		<rewrite>
+			<rules>${blockRule}
+				<rule name="app">
+					<match url="/*" />
+					<action type="Rewrite" url="node-server.cjs" />
+				</rule>
+			</rules>
+		</rewrite>
+		<!-- enableXFF="true" is required for getClientAddress to work -->
+		<iisnode watchedFiles="web.config;node_modules\\*;*.js;*.cjs" nodeProcessCommandLine="${
+      options.nodePath ?? 'node.exe'
+    }" enableXFF="true" />
+	</system.webServer>
+</configuration>
+`
+}

--- a/web.config.js
+++ b/web.config.js
@@ -21,12 +21,19 @@ export function createWebConfig(options) {
 			<add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
 		</handlers>
 		<rewrite>
-			<rules>
-				<!-- external routes that should be handled by IIS. For example, virtual directories -->
-				<rule name="block" stopProcessing="true">
-					<match url="^(${routes.join('|')})/*" ignoreCase="${
-            options.externalRoutesIgnoreCase ?? true
-          }" />
+			<rules>${
+        routes.length > 0
+          ? `
+                <!-- external routes that should be handled by IIS. For example, virtual directories -->
+                <rule name="block" stopProcessing="true">
+                    <match url="^(${routes.join('|')})/*" ignoreCase="${
+                      options.externalRoutesIgnoreCase ?? true
+                    }" />
+                    <action type="None" />
+                </rule>
+            `
+          : ''
+      }
 					<action type="None" />
 				</rule>
 				<rule name="app">

--- a/web.config.js
+++ b/web.config.js
@@ -1,52 +1,46 @@
 /** @param {import('.').createWebConfigOptions} options */
 export function createWebConfig(options) {
-  const routes = Array.from(new Set(options.externalRoutes ?? []))
-  // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
-  return `<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-	${
-    options.env
-      ? `
-	<appSettings>
-		${Object.entries(options.env)
-      .map(([key, val]) => `<add key="${key}" value="${val}" />`)
-      .join('\n\t\t')}
-	</appSettings>
-	`
-      : ''
+    const routes = Array.from(new Set(options.externalRoutes ?? []))
+    const blockRule = routes.length > 0  ? `
+                   <!-- external routes that should be handled by IIS. For example, virtual directories -->
+                   <rule name="block" stopProcessing="true">
+                       <match url="^(${routes.join('|')})/*" ignoreCase="${
+          options.externalRoutesIgnoreCase ?? true
+        }" />
+                       <action type="None" />
+                   </rule>` : '';
+    // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
+    return `<?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+      ${
+      options.env
+        ? `
+      <appSettings>
+          ${Object.entries(options.env)
+        .map(([key, val]) => `<add key="${key}" value="${val}" />`)
+        .join('\n\t\t')}
+      </appSettings>
+      `
+        : ''
+    }
+      <system.webServer>
+          <handlers>
+              <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+              <add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
+          </handlers>
+          <rewrite>
+              <rules>${blockRule}
+                  <rule name="app">
+                      <match url="/*" />
+                      <action type="Rewrite" url="node-server.cjs" />
+                  </rule>
+              </rules>
+          </rewrite>
+          <!-- enableXFF="true" is required for getClientAddress to work -->
+          <iisnode watchedFiles="web.config;node_modules\\*;*.js;*.cjs" nodeProcessCommandLine="${
+        options.nodePath ?? 'node.exe'
+      }" enableXFF="true" />
+      </system.webServer>
+  </configuration>
+  `
   }
-	<system.webServer>
-		<handlers>
-			<!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
-			<add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
-		</handlers>
-		<rewrite>
-			<rules>${
-        routes.length > 0
-          ? `
-                <!-- external routes that should be handled by IIS. For example, virtual directories -->
-                <rule name="block" stopProcessing="true">
-                    <match url="^(${routes.join('|')})/*" ignoreCase="${
-                      options.externalRoutesIgnoreCase ?? true
-                    }" />
-                    <action type="None" />
-                </rule>
-            `
-          : ''
-      }
-					<action type="None" />
-				</rule>
-				<rule name="app">
-					<match url="/*" />
-					<action type="Rewrite" url="node-server.cjs" />
-				</rule>
-			</rules>
-		</rewrite>
-		<!-- enableXFF="true" is required for getClientAddress to work -->
-		<iisnode watchedFiles="web.config;node_modules\\*;*.js;*.cjs" nodeProcessCommandLine="${
-      options.nodePath ?? 'node.exe'
-    }" enableXFF="true" />
-	</system.webServer>
-</configuration>
-`
-}


### PR DESCRIPTION
Excellent work with this repo, fits the needs I was looking for perfectly when trying to deploy a SvelteKit app with IIS!

However, the external route rewrite rule was a bit of a bump to get over when setting up the site. It kept giving me a 403.14 - Forbidden error until I noticed the rewrite rule named "block". 

In my project I don't have a need for external routes so when I didn't provide any external routes, the rewrite rule matches against ```^()/*``` which matches everything. I solved it by providing a "dummy"-route to the ```externalRoutes``` option in the ```svelte.config.js``` config but it would be neat to not have to do that and just have it disabled by default if no routes are provided.