### PR TITLE
Option to add rewrite rule for redirecting requests to https

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,12 @@ export interface AdapterOptions extends AdapterNodeAdapterOptions {
    * if not specified, form actions will likely return errror 403: Cross-site POST form submissions are forbidden
    */
   origin: string
+
+  /**
+   * whether to redirect http to https or not.
+   * @default false
+   */
+  redirectToHttps?: boolean
 }
 
 export default function plugin(options?: AdapterOptions): Adapter
@@ -57,5 +63,6 @@ export interface createWebConfigOptions {
   env: Record<string, string | number>
   nodePath?: string
   externalRoutes?: AdapterOptions['externalRoutes']
-  externalRoutesIgnoreCase?: AdapterOptions['externalRoutesIgnoreCase']
+  externalRoutesIgnoreCase?: AdapterOptions['externalRoutesIgnoreCase'],
+  redirectToHttps?: AdapterOptions['redirectToHttps']
 }

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ export default function (options) {
         nodePath: options?.overrideNodeExePath,
         externalRoutes: options?.externalRoutes,
         externalRoutesIgnoreCase: options?.externalRoutesIgnoreCase,
+        redirectToHttps: options?.redirectToHttps
       })
       const nodeServer = createNodeServer(options?.healthcheckRoute ?? true)
 

--- a/web.config.js
+++ b/web.config.js
@@ -7,9 +7,21 @@ export function createWebConfig(options) {
 				<!-- external routes that should be handled by IIS. For example, virtual directories -->
 				<rule name="block" stopProcessing="true">
 					<match url="^(${routes.join('|')})/*" ignoreCase="${
-          options.externalRoutesIgnoreCase ?? true
-        }" />
+            options.externalRoutesIgnoreCase ?? true
+          }" />
 					<action type="None" />
+				</rule>`
+      : ''
+  const redirectToHttps =
+    options.redirectToHttps ?? false
+      ? `
+				<!-- Redirects requests to https -->
+				<rule name="Redirect to https" stopProcessing="true">
+					<match url=".*" />
+					<conditions>
+						<add input="{HTTPS}" pattern="off" ignoreCase="true" />
+					</conditions>
+					<action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent" appendQueryString="false" />
 				</rule>`
       : ''
   // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
@@ -32,7 +44,7 @@ export function createWebConfig(options) {
 			<add name="iisnode" path="node-server.cjs" verb="*" modules="iisnode" />
 		</handlers>
 		<rewrite>
-			<rules>${blockRule}
+			<rules>${redirectToHttps}${blockRule}
 				<rule name="app">
 					<match url="/*" />
 					<action type="Rewrite" url="node-server.cjs" />

--- a/web.config.js
+++ b/web.config.js
@@ -7,8 +7,8 @@ export function createWebConfig(options) {
 				<!-- external routes that should be handled by IIS. For example, virtual directories -->
 				<rule name="block" stopProcessing="true">
 					<match url="^(${routes.join('|')})/*" ignoreCase="${
-            options.externalRoutesIgnoreCase ?? true
-          }" />
+          options.externalRoutesIgnoreCase ?? true
+        }" />
 					<action type="None" />
 				</rule>`
       : ''


### PR DESCRIPTION
Having the option to add a redirect rule for https would be a nice feature when setting up the configuration for the adapter. While this could be placed in the node-server.cjs file, the benefit of placing this in the web.config is that it still works for any requests towards the website, in case you have any virtual directories set up.