### PR TITLE
Fix for using prerendered routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function moveOutputToServerFolder() {
   const fileList = [
     'client',
     'server',
+    'prerendered',
     'env.js',
     'handler.js',
     'index.js',
@@ -20,6 +21,14 @@ function moveOutputToServerFolder() {
   fileList.forEach((f) => {
     const from = `build/${f}`
     const to = `${outputFolder}/app/${f}`
+
+    try {
+        fs.accessSync(from, fs.constants.F_OK)
+    } catch (err) {
+        // File doesn't exist
+        return
+    }
+
     fs.moveSync(from, to, (err) => console.error(err))
   })
 }


### PR DESCRIPTION
When defining routes as prerendered, `@sveltejs/adapter-node` generates .html-pages under `build/prerendered` which was missing in the list of files to move to the `.svelte-kit/adapter-iis` folder. It works fine while navigating from a hydrated route but trying to reload or access a prerendered route directly causes a 500 error.

I added the prerendered folder to the list and also a `fs.accessSync` check before trying to move each file in the list, if there's no `prerendered` folder it crashed.