### PR TITLE
Added config for httpErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,25 @@ npm run build
 You should try to bundle all your dependencies as dev dependencies so that you can skip this step however not all dependencies play nice. In this case you can install just the production dependencies using your preferred package manager.
 
 npm
+
 ```
 npm install --omit-dev
 ```
 
 pnpm
+
 ```bash
 pnpm install --P
 ```
 
 yarn
+
 ```bash
 yarn install --production=true
 ```
 
 bun
+
 ```bash
 bun install --production
 ```
@@ -274,6 +278,25 @@ const config = {
 ```
 
 By setting the option `redirectToHttps` to `true`, a URL Rewrite rule is applied to the `web.config` file that redirect all non-HTTPS request to HTTPS.
+
+## `httpErrors`
+
+By default IIS will take control of HTTP errors and show the default IIS `[STATUS].htm` for each status. If you want the SvelteKit application to handle all HTTP errors, you can specify `httpErrors.existingResponse` with `PassThrough` to let the application handle the errors.
+
+```js
+// svelte.config.js
+const config = {
+  //...
+  kit: {
+    adapter: IISAdapter({
+      // origin, ...
+      httpErrors: {
+        existingResponse: 'PassThrough',
+      },
+    }),
+  },
+}
+```
 
 ## Disclaimer
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,9 @@ export interface AdapterOptions extends AdapterNodeAdapterOptions {
 
   /** Allows you to configure the behavior of IISNode */
   iisNodeOptions?: IISNodeOptions
+
+  /** Allows you to configure the behaviour of http errors in IIS */
+  httpErrors?: HttpErrors
 }
 
 export interface IISNodeOptions {
@@ -139,4 +142,13 @@ export interface createWebConfigOptions {
   externalRoutes?: AdapterOptions['externalRoutes']
   externalRoutesIgnoreCase?: AdapterOptions['externalRoutesIgnoreCase']
   redirectToHttps?: AdapterOptions['redirectToHttps']
+  httpErrors?: AdapterOptions['httpErrors']
+}
+
+export interface HttpErrors {
+  /**
+   * Specifies what happens to an existing response when the HTTP status code is an error, i.e. response codes >= 400.
+   *
+   */
+  existingResponse?: 'Auto' | 'Replace' | 'PassThrough'
 }

--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ export default function (options) {
                 externalRoutes: options?.externalRoutes,
                 externalRoutesIgnoreCase: options?.externalRoutesIgnoreCase,
                 redirectToHttps: options?.redirectToHttps,
+                httpErrors: options?.httpErrors,
               })
             : createXMLTransform(env)
 

--- a/web.config.js
+++ b/web.config.js
@@ -42,6 +42,15 @@ function createAppSettingsEnv(env, isXMLTransform = false) {
 	`
 }
 
+/** @param {import('.').HttpErrors} httpErrors */
+function createHttpErrors(httpErrors) {
+  return `<httpErrors ${
+    httpErrors.existingResponse ?? false
+      ? `existingResponse="${httpErrors.existingResponse}"`
+      : ''
+  } />`
+}
+
 /** @param {import('.').createWebConfigOptions["iisNodeOptions"]} options */
 function createIISNodeConfig(options) {
   const defaults = {
@@ -77,6 +86,8 @@ export function createWebConfig(options) {
           3
         )
       : ''
+  const httpErrors =
+    options.httpErrors ?? false ? createHttpErrors(options.httpErrors) : ''
 
   // <?xml version="1.0" encoding="utf-8"?> has to be on the first line!
   return `<?xml version="1.0" encoding="utf-8"?>
@@ -96,6 +107,7 @@ export function createWebConfig(options) {
 				</rule>
 			</rules>
 		</rewrite>
+        ${httpErrors}
 		${createIISNodeConfig(options.iisNodeOptions)}
 	</system.webServer>
 </configuration>


### PR DESCRIPTION
In our application we don't want to rely on the IIS server serving the default `[STATUS].htm` file whenever the user encounters a 4xx error and a global setting for all our IIS websites in the IIS server isn't desirable, as some websites rely on the default handling of errors in IIS. We'd rather pass through the error handling to the SvelteKit application.

I've added an optional config for setting the `httpErrors.existingResponse` attribute to Auto, Replace or PassThrough. The `httpErrors`-config could be extended to include more attributes in the future, as specified in the [\<httpErrors\>-docs](https://learn.microsoft.com/en-us/iis/configuration/system.webserver/httperrors/), but I'm not familiar enough with the other attributes to know if some other config is required as well.